### PR TITLE
Fix scheduler defaults and platform registry

### DIFF
--- a/scripts/smokeBlueskyPost.ts
+++ b/scripts/smokeBlueskyPost.ts
@@ -4,8 +4,6 @@ import { sendPost } from "../src/services/postService";
 import { env } from "../src/env";
 import type { PlatformEnv } from "../src/platforms/types";
 
-const {serverUrl, identifier, appPassword } =env.bluesky;
-
 const bskyEnv = {
   serverUrl: env.bluesky.serverUrl,
   identifier: env.bluesky.identifier,
@@ -14,7 +12,7 @@ const bskyEnv = {
 
 function requireField(name: keyof typeof bskyEnv) {
   if (!bskyEnv[name]) {
-    throw new Error(`Missing Bluesky env var: ${name}`);
+    throw new Error(`Missing Bluesky env var: ${String(name)}`);
   }
 }
 requireField("serverUrl");

--- a/scripts/smokeMastodonPost.ts
+++ b/scripts/smokeMastodonPost.ts
@@ -9,7 +9,10 @@ async function main() {
   const res = await sendPost(
     { content: "Hallo Mastodon 👋 (Smoke Test)" },
     "mastodon",
-    { serverUrl: env.mastodon.serverUrl, token: env.mastodon.token }
+    {
+      apiUrl: env.mastodon.apiUrl,
+      accessToken: env.mastodon.accessToken,
+    }
   );
 
   console.log("Posted:", res.uri, "at", res.postedAt.toISOString());

--- a/src/config.js
+++ b/src/config.js
@@ -1,11 +1,15 @@
 // src/config.js
 require("dotenv").config();
 
-const path = require('path');
+const DEFAULT_CRON = "0 9 * * *"; // Standard: jeden Tag um 9 Uhr
 
 module.exports = {
-  //  SCHEDULE_TIME: "0 9 * * *", // Standard jeden Tag um 9 Uhr
-  PORT: 3000, // Standard Port
-  TIME_ZONE: process.env.VITE_TIME_ZONE || "Europe/Berlin", // Standard Zeitzone
-  LOCALE: process.env.VITE_LOCALE || "de-DE", // Standard Sprache
+  SCHEDULE_TIME:
+    process.env.SCHEDULE_TIME ||
+    process.env.VITE_SCHEDULE_TIME ||
+    DEFAULT_CRON,
+  PORT: parseInt(process.env.PORT ?? "", 10) || 3000,
+  TIME_ZONE:
+    process.env.TIME_ZONE || process.env.VITE_TIME_ZONE || "Europe/Berlin",
+  LOCALE: process.env.LOCALE || process.env.VITE_LOCALE || "de-DE",
 };

--- a/src/platforms/registry.js
+++ b/src/platforms/registry.js
@@ -1,25 +1,26 @@
 const { PLATFORMS } = require("./types");
-const blueskyClient = require("../services/blueskyClient");
-const mastodonClient = require("../services/mastodonClient");
 
-/**
- * Vereinheitliche hier die Methoden-Namen mit deinen Services.
- * Ich nehme an, beide Clients exportieren z.B. sendPost / sendScheduled / health.
- */
-const registry = {
-  [PLATFORMS.BLUESKY]: {
-    sendPost: blueskyClient.sendPost,
-    sendScheduled: blueskyClient.sendScheduled, // falls vorhanden
-    health: blueskyClient.health, // falls vorhanden
-  },
-  [PLATFORMS.MASTODON]: {
-    sendPost: mastodonClient.sendPost,
-    sendScheduled: mastodonClient.sendScheduled,
-    health: mastodonClient.health,
-  },
-};
+/** @type {Map<string, any>} */
+const registry = new Map();
+
+function registerProfile(profile) {
+  if (!profile || typeof profile.id !== "string") {
+    throw new Error("Profil muss eine eindeutige 'id' besitzen.");
+  }
+
+  registry.set(profile.id, profile);
+}
+
+function getProfile(id) {
+  if (!id) {
+    return null;
+  }
+
+  return registry.get(id) ?? null;
+}
 
 module.exports = {
-  registry,
+  registerProfile,
+  getProfile,
   PLATFORMS,
 };

--- a/src/platforms/setup.js
+++ b/src/platforms/setup.js
@@ -1,8 +1,10 @@
-const registerProfile = require("./registry");
+const { registerProfile } = require("./registry");
 const blueskyProfile = require("./bluesky/blueksyProfile");
 const mastodonProfile = require("./mastodon/mastodonProfile");
 
-module.exports = function setupPlatforms() {
+function setupPlatforms() {
   registerProfile(blueskyProfile);
   registerProfile(mastodonProfile);
 }
+
+module.exports = { setupPlatforms };

--- a/src/platforms/types.d.ts
+++ b/src/platforms/types.d.ts
@@ -1,0 +1,26 @@
+export type TargetPlatform = "bluesky" | "mastodon";
+
+export type PlatformEnv = Record<string, string | undefined>;
+
+export interface PlatformProfile<
+  TInput = { content: string; scheduledAt?: string | Date | null },
+  TEnv extends PlatformEnv = PlatformEnv,
+> {
+  id: TargetPlatform | string;
+  displayName: string;
+  maxChars?: number;
+  countMethod?: string;
+  description?: string;
+  validate(input: TInput): { ok: boolean; remaining: number; errors?: string[] };
+  toPostPayload(input: TInput): unknown;
+  post(payload: unknown, env: TEnv): Promise<{
+    uri: string;
+    postedAt: Date;
+    raw?: unknown;
+  }>;
+}
+
+export declare const PLATFORMS: {
+  BLUESKY: "bluesky";
+  MASTODON: "mastodon";
+};

--- a/src/services/scheduler.js
+++ b/src/services/scheduler.js
@@ -1,10 +1,18 @@
 const cron = require("node-cron");
 const config = require("../config");
 const { postSkeet } = require("./blueskyClient");
-const Skeet = require("../models/skeetModel");
+const { Skeet } = require("../models");
 
 function scheduleSkeetPosting(content) {
-  cron.schedule(config.SCHEDULE_TIME, async () => {
+  const schedule = config.SCHEDULE_TIME;
+
+  if (!cron.validate(schedule)) {
+    throw new Error(
+      `Ungültiger Cron-Ausdruck für SCHEDULE_TIME: "${schedule}"`
+    );
+  }
+
+  cron.schedule(schedule, async () => {
     try {
       console.log(`Poste Skeet: ${content}`);
       const post = await postSkeet(content);


### PR DESCRIPTION
## Summary
- add environment-driven defaults for the scheduler configuration
- make the scheduler use the initialized Sequelize model and validate cron expressions
- rework the platform registry/setup and smoke tests, including new platform typings

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cbdf4e8078832d82daad1486375c47