### PR TITLE
docs: refresh and expand documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,88 @@
 # Bluesky Kampagnen-Tool
 
-Ein Open-Source-Tool zur **automatisierten, geplanten Veröffentlichung und Verwaltung** von Bluesky-Posts (Skeets) und Threads – inklusive Mandantenfähigkeit, sicherer Zugangsdaten-Verwaltung und erweiterbaren Analysefunktionen.  
-Entwickelt mit **Node.js (Express)**, **React (Vite)**, **Sequelize** und einer **API-Architektur**, die sowohl lokal als auch in der Cloud betrieben werden kann.
+Das Bluesky Kampagnen-Tool ist ein Open-Source-Projekt für die **geplante Veröffentlichung und Verwaltung** von Bluesky-Posts (Skeets) und Threads. Es kombiniert eine Express-API, ein React-Dashboard und einen robusten Scheduler, sodass Kampagnen sicher vorbereitet und automatisiert ausgeliefert werden können – lokal, auf dem eigenen Server oder in Containern betrieben.
+
+---
+
+## Projektziele
+
+- Kampagnen mit mehreren Skeets oder kompletten Threads vorbereiten und punktgenau veröffentlichen.
+- Mandanten sauber voneinander trennen, inklusive Rollen- und Rechteverwaltung.
+- Zugangsdaten verschlüsselt speichern und Erweiterungen (z. B. 2FA, zusätzliche Plattformen) vorbereiten.
+- Reaktionen von Bluesky abrufen, um Wirkung und Reichweite sichtbar zu machen.
 
 ---
 
 ## Funktionsumfang (aktueller Planungsstand)
 
-- **Planung & Veröffentlichung**
-  - Einzelne Skeets oder komplette Threads zu beliebigen Zeitpunkten posten
-  - Unicode-Graphem-Zählung (Bluesky-kompatibel)
-  - Medienanhänge mit Alt-Texten
-- **Kampagnen-Management**
-  - Mehrere Kampagnen pro Tenant
-  - Übersicht aller geplanten, gesendeten, fehlgeschlagenen und archivierten Posts
-  - Status- und Zeitfilter
-- **Multi-Tenant-Unterstützung**
-  - Getrennte Datenhaltung pro Organisation
-  - Rollen & Rechte (Owner, Admin, Editor, Viewer)
-- **Sicherheit**
-  - Passwort-Hashing (Argon2id) für lokale Logins
-  - Verschlüsselte Speicherung von Bluesky-Zugangsdaten (AES-GCM)
-  - Vorbereitet für 2FA (TOTP, Backup-Codes)
-- **Scheduler**
-  - Hintergrundjobs mit Retry-Logik und Backoff
-  - Concurrency-Limits pro Tenant
-- **Analysen**
-  - Erfassung von Likes, Reposts, Replies
-  - Zeitreihen-Auswertung pro Skeet/Thread
-- **Zukunft**
-  - Erweiterung zu einem vollständigen Bluesky-Client (Timeline, Interaktion, Listen)
+### Planung & Veröffentlichung
+- Einzelne Skeets oder komplette Threads zeitgesteuert posten.
+- Unicode-Graphem-Zählung (Bluesky-konform) und Validierung des Zeichenvorrats.
+- Medienanhänge inklusive Alt-Texten vorbereiten.
+
+### Kampagnen-Management
+- Mehrere Kampagnen pro Tenant verwalten.
+- Statusübersichten für geplante, gesendete, fehlgeschlagene und archivierte Beiträge.
+- Filter nach Status, Zeit und Kampagne.
+
+### Multi-Tenant-Unterstützung
+- Strikte Mandantentrennung in der Datenbank.
+- Rollenmodell (Owner, Admin, Editor, Viewer) mit abgestuften Rechten.
+
+### Sicherheit
+- Passwort-Hashing mit Argon2id für lokale Logins.
+- AES-GCM-verschlüsselte Speicherung von Bluesky-Zugangsdaten.
+- Vorbereitete Strukturen für TOTP-basierte Zwei-Faktor-Authentifizierung.
+
+### Scheduler
+- Hintergrundjobs mit Retry-Logik, Backoff und Concurrency-Limits pro Tenant.
+- Status-Tracking und Benachrichtigung des Dashboards.
+
+### Analysen
+- Erfassung von Likes, Reposts und Replies.
+- Zeitreihen-Auswertungen pro Skeet/Thread in Planung.
+
+### Perspektive
+- Ausbau zu einem vollständigen Bluesky-Client mit Timeline, Interaktionen und Listenverwaltung.
+
+---
+
+## Technologie-Stack
+
+- **Backend:** Node.js (Express), TypeScript, Sequelize, PostgreSQL/MySQL/SQLite
+- **Frontend:** React (Vite), TypeScript, Tailwind/Shadcn UI
+- **Jobs & Scheduler:** Node-basierter Worker mit Queue- und Retry-Mechanismen
+- **Infrastruktur:** Betrieb lokal, als Service oder per Docker Compose
 
 ---
 
 ## Installation
 
-Wähle die für dich passende Installationsmethode:
+Wähle die passende Installationsmethode aus den Anleitungen unter `docs/installation/`:
 
-- **[Option A: Installation auf lokalem PC oder Server](./docs/installation/local-install.md)**  
-  Für lokale Entwicklung oder direkten Betrieb ohne Container.
+- **[Option A: Installation auf lokalem PC oder Server](./docs/installation/local-install.md)** – lokale Entwicklung oder Betrieb ohne Container.
+- **[Option B: Manuelle Server-Installation](./docs/installation/server-install.md)** – produktiver Betrieb mit manueller Einrichtung der Umgebung.
+- **[Option C: Installation im Docker-Container](./docs/installation/docker-install.md)** – reproduzierbarer Betrieb mit Docker Compose.
 
-- **[Option B: Manuelle Installation auf einem Server](./docs/installation/server-install.md)**  
-  Für produktiven Betrieb mit manueller Einrichtung aller Abhängigkeiten.
-
-- **[Option C: Installation im Docker Container](./docs/installation/docker-install.md)**  
-  Für eine schnelle, reproduzierbare Container-Installation mit Docker Compose.
 ---
 
-## Architektur & Diagramme
+## Dokumentation & Architektur
 
-Die Architektur ist in einzelne Diagramme aufgeteilt und im Ordner docs/diagramme dokumentiert:
+- **[Dokumentenübersicht](./docs/README.md)** – Einstieg in Architektur, Diagramme und weiterführende Unterlagen.
+- **[Roadmap](./docs/ROADMAP.md)** – geplanter Ausbau in drei Entwicklungsphasen.
+- **[Diagramme](./docs/diagramme)** – Systemarchitektur, Datenfluss, Statusdiagramme und Farbdefinitionen.
+- **[Agentenbeschreibung](./docs/Agent.md)** – Rolle des Kampagnen-Agents und seine Interaktionen.
 
-**Systemarchitektur** – Überblick über die Hauptkomponenten
-
-**Datenfluss** – Ablauf beim Planen & Posten
-
-**Lebenszyklus Skeet** – Zustände und Übergänge für einzelne Posts
-
-**Lebenszyklus Thread** – Zustände und Übergänge für Threads
-
-**Statusfarben-Legende** – Farbdefinitionen für UI & Diagramme
-
-## Roadmap
-Die geplante Weiterentwicklung ist in der ROADMAP.md beschrieben – von der minimalen Kampagnen-Version bis hin zur vollständigen Bluesky-Client-Suite.
+---
 
 ## Sicherheitshinweise
-Keine Zugangsdaten in öffentliche Repos hochladen!
 
-.env immer in .gitignore eintragen.
+- Keine Zugangsdaten in Repositories oder Tickets hochladen.
+- `.env` und andere Geheimnisse immer in `.gitignore` belassen und sicher verwahren.
+- Für produktive Installationen starke Passwörter, eigene App-Keys und verschlüsselte Backups einsetzen.
 
-Für Produktivbetrieb: Eigene App-Keys und starke Passwörter nutzen.
+---
 
 ## Lizenz
-Dieses Projekt steht unter der GNU General Public License (GPL).
-Siehe LICENSE für Details.
+
+Dieses Projekt steht unter der **GNU General Public License (GPL)**. Details siehe [LICENSE](./LICENSE).

--- a/dashboard/src/styles/README.md
+++ b/dashboard/src/styles/README.md
@@ -1,27 +1,43 @@
 # Style-Guide für das Dashboard
 
-Dieser Ordner bündelt alle Styles des Dashboards. Die Dateien sind nach Verantwortlichkeiten getrennt und bauen auf gemeinsamen Design-Tokens auf.
+Dieser Ordner bündelt alle Styles des Dashboards. Die Dateien sind nach Verantwortlichkeiten getrennt und nutzen gemeinsame Design-Tokens.
+
+---
 
 ## Design-Tokens (`variables.css`)
-- Enthält alle globalen Farben, Abstände, Radien, Typografie- und Transition-Werte.
+
+- Enthält globale Farben, Abstände, Radien, Typografie- und Transition-Werte.
 - Dark-Mode-Varianten werden über `prefers-color-scheme: dark` verwaltet und überschreiben nur die nötigen Variablen.
-- Neue Komponenten sollten ausschließlich auf diese Tokens zurückgreifen, statt eigene Farb- oder Abstandsangaben zu definieren.
+- Neue Komponenten sollten ausschließlich auf diese Tokens zurückgreifen.
 
 ## Basis-Stile (`base.css`)
-- Legt Grundtypografie (`body`, Überschriften) und Standard-Button-Verhalten fest.
-- Buttons erhalten konsistente Hover-, Active- und Focus-States inklusive Fokus-Markierung für Tastatursteuerung.
+
+- Definiert Grundtypografie (`body`, Überschriften) und globale Bedienelemente.
+- Button-States (Hover, Active, Focus) inklusive Fokus-Markierungen für Tastatursteuerung.
+
+## Anwendungs-Wrapper (`App.css`)
+
+- Enthält App-weite Layoutregeln (Grid/Flex) und definiert, wie Seitenabstände und Scroll-Verhalten umgesetzt werden.
+- Importiert gemeinsame Tokens und sorgt dafür, dass globale Hintergründe/Statusfarben konsistent bleiben.
 
 ## Layout & Komponenten
-- `layout.css`: Steuert Karten- und Listenlayouts und nutzt semantische Statusfarben für geplante bzw. veröffentlichte Skeets.
-- `menu.css`: Beschreibt die Tab-Navigation inklusive Burger-Menü für kleine Screens.
-- `skeet-form.css`: Enthält Formularlayout, Fokus-Styling für Eingaben sowie Toggles für Zielplattformen.
+
+- `layout.css`: Karten- und Listenlayouts, Statusfarben für geplante bzw. veröffentlichte Skeets.
+- `menu.css`: Tab-Navigation inklusive Burger-Menü für kleine Screens.
+- `skeet-form.css`: Formularlayout, Fokus-Styling sowie Toggles für Zielplattformen.
+
+---
 
 ## Arbeitsweise
-1. Tokens prüfen: Passt ein bestehendes Token? Falls nein, dieses in `variables.css` ergänzen.
-2. Verhalten definieren: Komponenten-spezifische Interaktionen (Hover, Fokus) direkt in der jeweiligen Datei abbilden.
-3. Dokumentieren: Kurze Kommentarblöcke am Dateianfang beschreiben Zweck und Geltungsbereich.
 
-## Testing & Qualität
+1. **Tokens prüfen:** Passt ein bestehendes Token? Falls nein, neues Token in `variables.css` ergänzen und dokumentieren.
+2. **Verhalten definieren:** Komponenten-spezifische Interaktionen (Hover, Fokus) direkt in der jeweiligen Datei abbilden.
+3. **Dokumentation pflegen:** Kurze Kommentarblöcke am Dateianfang beschreiben Zweck und Geltungsbereich.
+
+---
+
+## Qualitätssicherung
+
 - Styles im hellen und dunklen Modus testen (OS-Einstellung oder DevTools).
-- Buttons und Eingaben per Tastatur (`Tab`) ansteuern, um den Fokus-Stil zu prüfen.
-- Kontrast mit gängigen Checkern (z. B. WebAIM) gegen WCAG AA verifizieren, wenn Farben geändert werden.
+- Bedienelemente per Tastatur (`Tab`) fokussieren, um den Fokus-Stil zu prüfen.
+- Kontrast mit Checkern wie WebAIM gegen WCAG AA verifizieren, wenn Farben geändert werden.

--- a/docs/Agent.md
+++ b/docs/Agent.md
@@ -1,74 +1,82 @@
-# Agent.md
+# Kampagnen-Agent
 
-## Name
-Campaign Agent
+Der Kampagnen-Agent ist die Automatisierungsschicht des Projekts. Er koordiniert Planung, Speicherung und Veröffentlichung von Kampagneninhalten auf Bluesky und bildet die Grundlage für weitere Plattform-Integrationen.
 
-## Rolle
-Der Agent automatisiert die Veröffentlichung und Verwaltung von Kampagneninhalten auf sozialen Plattformen.  
-Er stellt sicher, dass Beiträge zeitlich geplant, rechtssicher formuliert, in Threads strukturiert und nachverfolgt werden können.
+---
 
-## Aufgaben
-- **Skeets posten**  
-  Veröffentlichung einzelner Skeets auf Bluesky mit Unicode-Zeichenlimit (300 Zeichen).
-- **Threads verwalten**  
-  Erstellung, Planung und Verwaltung von mehrteiligen Beiträgen mit klarer Nummerierung.  
-  Unterstützung für erzwungene Thread-Trennung.
-- **Scheduler**  
-  Zeitgenaue Planung und automatische Veröffentlichung von Posts (inkl. Zeitzonen-Handling).
-- **Multi-Tenant Support**  
-  Mehrere Kampagnen/Accounts parallel verwalten, getrennte Logins und Konfigurationen.
-- **Reaktions-Tracking**  
-  Erfassen von Likes, Reposts und Replies zur Auswertung der Kampagnenwirkung.
-- **Dashboard**  
-  Frontend-Komponenten für Verwaltung, Vorschau und Planung von Kampagnen (React-UI).
-- **Plattform-Setup**  
-  Abstraktion für verschiedene Plattformen (aktuell Bluesky, später Mastodon etc.).
-- **Zeichenzähler**  
-  Überprüfung von Beiträgen gegen die Plattformgrenzen (Unicode-Grapheme).
-- **Migration & Versionierung**  
-  Nutzung von Sequelize-Migrations für strukturierte Datenbankentwicklung.
+## Rolle & Verantwortlichkeiten
+
+- **Planung umsetzen:** Zeitsensitive Veröffentlichung einzelner Skeets oder kompletter Threads durchführen.
+- **Mandanten trennen:** Kampagnen, Accounts und Zugangsdaten tenant-spezifisch verwalten.
+- **Sicherheit gewährleisten:** Zugangsdaten verschlüsseln, Logins absichern und Wiederholungsversuche kontrollieren.
+- **Monitoring bereitstellen:** Status-Updates, Logs und Analysedaten für das Dashboard liefern.
+- **Plattformen abstrahieren:** Schnittstellen kapseln, um neben Bluesky weitere Plattformen anbinden zu können.
+
+---
+
+## Kernaufgaben
+
+| Bereich            | Beschreibung |
+|--------------------|--------------|
+| **Skeets & Threads** | Posts validieren, Unicode-Grapheme zählen, Medienanhänge samt Alt-Texten verarbeiten. |
+| **Scheduler**        | Jobs nach Zeitzone terminieren, Retries mit Backoff steuern und Ergebnisse zurückmelden. |
+| **Multi-Tenancy**    | Mandanten- und Benutzerkontexte erzwingen, Rollen (`owner`, `admin`, `editor`, `viewer`) berücksichtigen. |
+| **Reaktions-Tracking** | Likes, Reposts und Replies abrufen und historisieren. |
+| **Dashboard-Anbindung** | APIs für Planung, Vorschau und Monitoring bereitstellen. |
+
+---
 
 ## Eingaben
-- Textinhalte für Skeets/Threads  
-- Geplanter Veröffentlichungszeitpunkt  
-- Account/Kampagnen-Zuordnung  
-- Plattform-Konfiguration (API-Tokens, Secrets)  
-- Optionale Metadaten (Alt-Text, Sharepics, Quellen)
+
+- Kampagnen- und Account-Daten (Tenant, Rollen, Status)
+- Texte, Medien und Metadaten für Skeets/Threads
+- Geplante Veröffentlichungszeitpunkte und Wiederholungsregeln
+- Plattformkonfigurationen (z. B. Bluesky-Identifier, App-Passwörter)
 
 ## Ausgaben
-- Veröffentlichung auf Zielplattform(en)  
-- Logfiles der erfolgreichen oder fehlerhaften Veröffentlichungen  
-- Tracking-Daten zu Reichweite und Reaktionen  
-- Vorschau im Dashboard
+
+- Erfolgreich veröffentlichte Posts inklusive Plattform-URI
+- Fehlermeldungen und Logs bei abgebrochenen Versuchen
+- Status- und Analysedaten für das Dashboard
+
+---
 
 ## Interaktionen
-- **User**: erstellt Kampagnen, plant Skeets/Threads, prüft Reaktionen.  
-- **Datenbank**: persistiert Kampagnen, Posts, Threads, Scheduler-Jobs, Reaktionen.  
-- **Plattform-APIs**: Bluesky (ATProto), künftig Mastodon und andere soziale Netzwerke.  
-- **Dashboard**: UI zur Eingabe, Bearbeitung, Vorschau und Monitoring.
+
+- **Benutzer:innen:** Planen Kampagnen, bearbeiten Inhalte, prüfen Ergebnisse.
+- **Backend-Datenbank:** Persistiert Kampagnen, Posts, Jobs, Reaktionen und Credentials.
+- **Scheduler-Worker:** Führt geplante Jobs aus und meldet Status zurück.
+- **Plattform-APIs:** Aktuell Bluesky (ATProto); Architektur ist auf weitere Netzwerke vorbereitet.
+- **Dashboard:** Visualisiert Status, Auswertungen und bietet Eingabeformulare.
+
+---
+
+## Konfiguration & Betrieb
+
+### Environment-Variablen (Auszug)
+
+- `DATABASE_URL` – Datenbankverbindung (SQLite, PostgreSQL oder MySQL)
+- `SESSION_SECRET` – Schlüssel für Sitzungs- und Tokenverschlüsselung
+- `BLUESKY_IDENTIFIER` / `BLUESKY_APP_PASSWORD` – Plattformzugang
+- `PORT` – API- bzw. Dashboard-Port
+- `NODE_ENV` – Laufzeitumgebung (`development`, `production`)
+
+### Migrationen & Versionierung
+
+- Sequelize-Migrationen für Kampagnen, Skeets/Threads, Plattformkonten, Credentials und Reaktionen
+- Versionierte Seeds und Tests für Kern-Workflows
+
+### Frontend-Komponenten
+
+- React-basierte Formulare (z. B. `SkeetForm`, `ThreadComposer`, `CampaignDashboard`)
+- Konsistente Statusfarben und Zeitachsen basierend auf den Diagrammdefinitionen
+
+---
 
 ## Beispielablauf
-1. User erstellt im Dashboard eine neue Kampagne.  
-2. User fügt Skeets/Threads hinzu und plant Veröffentlichungszeitpunkte.  
-3. Agent speichert die Daten in der Datenbank und legt Scheduler-Jobs an.  
-4. Zum geplanten Zeitpunkt veröffentlicht der Agent die Inhalte auf der gewählten Plattform.  
-5. Agent trackt Reaktionen (Likes, Reposts, Replies) und speichert diese zur Auswertung.  
-6. Dashboard zeigt Statistiken und Kampagnenstatus an.
 
-## Konfiguration
-- **ENV Variablen**
-  - `DATABASE_URL` – Verbindung zur SQLite/Postgres DB  
-  - `SESSION_SECRET` – Verschlüsselung von Tokens  
-  - `BLUESKY_IDENTIFIER` / `BLUESKY_PASSWORD` – API-Zugangsdaten  
-  - `PORT` – Serverport für Dashboard  
-  - `NODE_ENV` – Umgebung (development/production)
-
-- **Migrationen**
-  - Skeet & Thread Models  
-  - Kampagnen Model  
-  - Plattform Model  
-  - Reaction Model
-
-- **Frontend**
-  - React mit Tailwind, shadcn/ui, lucide-icons  
-  - Komponenten: SkeetForm, ThreadView, CampaignDashboard
+1. Benutzer:in erstellt eine Kampagne im Dashboard und plant Skeets oder Threads.
+2. Der Agent speichert Inhalte, verschlüsselt Zugangsdaten und legt Scheduler-Jobs an.
+3. Zum geplanten Zeitpunkt löst der Scheduler den Job aus; der Agent veröffentlicht den Post.
+4. Rückmeldungen der Bluesky-API werden verarbeitet, Status aktualisiert und Logs erstellt.
+5. Dashboard und Analysen zeigen den finalen Zustand und Reaktionswerte an.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,23 +1,35 @@
-# Architekturübersicht
+# Dokumentationsübersicht
 
-Dieser Bereich dokumentiert die technische Architektur des **BSky-Kampagnen-Bot**.
-
-## Inhalt
-
-- **[ROADMAP.md](./ROADMAP.md)** – Entwicklungsphasen von der Minimalversion bis zur vollständigen Bluesky-Client-Suite.
-- **[systemarchitektur.md](./diagramme//systemarchitektur.md)** – Gesamtüberblick der Systemkomponenten, Datenflüsse und externen Abhängigkeiten.
-- **[datenbankchema.md](./diagramme/datenbankschema.md)** – Entwurf des relationalen Schemas inkl. Multi-Tenant-Design und Kampagnenstruktur.
-- **[sicherheitskonzept.md](./sicherheitskonzept.md)** – Maßnahmen zur sicheren Speicherung von Zugangsdaten, Passwort-Hashing und Mandantentrennung.
-- **[schedulerlogik.md](./schedulerlogik.md)** – Ablaufpläne und Statusmaschinen für geplante Posts und Threads.
-- **[erweiterungen.md](./erweiterungen.md)** – Geplante Zusatzfunktionen und Integrationen (z. B. vollständiger Bluesky-Client).
-
-## Zweck
-
-Die Dokumente im Ordner `architektur/` dienen als Referenz für Entwickler:innen und Mitwirkende, um:
-- das Systemdesign zu verstehen,
-- technische Entscheidungen nachzuvollziehen,
-- Erweiterungen konsistent umzusetzen.
+Dieser Bereich bündelt die begleitende Dokumentation für den **BSky-Kampagnen-Bot**. Sie richtet sich an Entwickler:innen, Operator:innen und Beitragende, die Architektur, Installation und Planung nachvollziehen möchten.
 
 ---
 
-*Hinweis:* Alle Diagramme und technischen Skizzen sollten, wenn möglich, als editierbare Quelldateien (z. B. `.drawio`) und zusätzlich als exportierte PNG/SVG-Version abgelegt werden.
+## Installationsleitfäden
+
+- **[Allgemeine Übersicht](./installation/installation.md)** – Entscheidungshilfe für die passende Installationsvariante.
+- **[Lokale Installation](./installation/local-install.md)** – Setup für Entwicklung und Tests auf dem eigenen Rechner.
+- **[Manuelle Server-Installation](./installation/server-install.md)** – Betrieb auf einem dedizierten (v)Server ohne Container.
+- **[Docker-Installation](./installation/docker-install.md)** – Betrieb über Docker Compose inklusive Backend, Frontend und Datenbank.
+
+---
+
+## Architektur & Prozesse
+
+- **[Systemarchitektur](./diagramme/systemarchitektur.md)** – Überblick über Hauptkomponenten und deren Kommunikation.
+- **[Datenfluss](./diagramme/datenfluss.md)** – Sequenzdiagramm für Planung und Versand eines Posts.
+- **[Lebenszyklus Skeet](./diagramme/lebenszyklus_skeet.md)** – Zustandsdiagramm eines einzelnen Posts.
+- **[Lebenszyklus Thread](./diagramme/lebenszyklus_thread.md)** – Zustandsdiagramm eines mehrteiligen Threads.
+- **[Statusfarben](./diagramme/statusfarben.md)** – Referenz für einheitliche UI- und Diagrammfarben.
+
+---
+
+## Planung & Rollen
+
+- **[Roadmap](./ROADMAP.md)** – geplanter Funktionsumfang in drei Projektphasen.
+- **[Agentenbeschreibung](./Agent.md)** – Verantwortlichkeiten des Kampagnen-Agents und seine Schnittstellen.
+
+---
+
+### Hinweis zu Diagrammen
+
+Die Mermaid-Diagramme lassen sich direkt in GitHub anzeigen. Für Anpassungen empfiehlt sich ein Editor wie [https://mermaid.live](https://mermaid.live/) oder ein kompatibles Diagramm-Tool.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,102 +1,57 @@
 # Roadmap – BSky-Kampagnen-Bot
 
-Diese Roadmap skizziert den geplanten Funktionsumfang des Projekts in drei Entwicklungsphasen.  
-Sie ist so aufgebaut, dass jede Phase produktiv nutzbar ist, aber die Architektur von Anfang an auf **Skalierbarkeit**, **Sicherheit** und **Erweiterbarkeit** ausgelegt wird.
+Die Roadmap gliedert die Entwicklung in drei auslieferbare Phasen. Jede Phase liefert ein produktiv nutzbares System, während Architektur und Sicherheit von Anfang an auf Skalierung, Mandantentrennung und Erweiterbarkeit ausgerichtet werden.
 
 ---
 
-## **Phase 1 – Minimaler Kampagnen-Bot**
-**Ziel:** Funktionsfähige Open-Source-Anwendung, die geplante Skeets und Threads automatisch posten kann.
+## Phase 1 – Minimaler Kampagnen-Bot
+
+**Ziel:** Automatisiertes Planen und Posten von Skeets/Threads mit grundlegender Sicherheit.
 
 ### Kernfunktionen
-- **Skeets planen und veröffentlichen**  
-  - Unterstützung für Einzelposts und Threads  
-  - Unicode-Graphem-Zählung (Bluesky-kompatibel)  
-  - Medienanhänge mit Alt-Texten
-- **Scheduler**
-  - Zeitplanung in UTC mit Campaign-spezifischer Zeitzone  
-  - Einmalige und wiederkehrende Posts  
-  - Warteschlange mit Status (`pending`, `running`, `done`, `failed`)
-- **Einfache Kampagnenstruktur**
-  - Campaign-Tabelle mit Name, Zeitzone, Zeitraum, Status  
-  - Skeets/Threads einer Campaign zugeordnet
-- **Speicherung**
-  - SQLite als Default (Zero-Config)  
-  - MySQL/Postgres optional (per `.env`-Konfiguration)
-- **Basis-Sicherheit**
-  - Master-Key-gestützte Verschlüsselung für Bluesky-Credentials  
-  - Keine Speicherung von Klartext-Passwörtern oder Tokens  
-  - Minimaler User-Login (lokal, Passwort gehasht)
+
+- Skeets und Threads planen, Unicode-Grapheme zählen, Medienanhänge mit Alt-Texten verwalten.
+- Scheduler mit UTC-Zeitplan, optionalen Wiederholungen und Status-Warteschlange (`pending`, `running`, `done`, `failed`).
+- Kampagnen-Grundstruktur mit Zeitzone, Zeitraum und Status.
+- Speicherung wahlweise per SQLite (Standard) oder PostgreSQL/MySQL über `.env`.
+- Sicherheit: Argon2id-Hashing für Nutzerpasswörter, verschlüsselte Speicherung von Bluesky-Credentials.
 
 ---
 
-## **Phase 2 – Multi-Tenant-Kampagnen-Suite**
-**Ziel:** Mehrere Mandanten (Organisationen) können unabhängig voneinander arbeiten, mit sauberer Trennung aller Daten und Rechte.
+## Phase 2 – Multi-Tenant-Kampagnen-Suite
+
+**Ziel:** Mehrere Organisationen können unabhängig voneinander arbeiten, inklusive Rollen und erweiterten Tools.
 
 ### Erweiterungen
-- **Multi-Tenancy**
-  - `tenant_id` in allen relevanten Tabellen  
-  - Tenant-weite Unique-Constraints  
-  - Mandantenbezogene Filter in allen Queries
-- **Benutzer- und Rollenverwaltung**
-  - Benutzerkonten pro Tenant  
-  - Rollen: `owner`, `admin`, `editor`, `viewer`  
-  - Einladungssystem mit E-Mail-Verifizierung
-- **Erweiterte Scheduler-Funktionen**
-  - Job-Retries mit Backoff  
-  - Concurrency-Limits pro Tenant  
-  - Abbruch und Neuplanung geplanter Posts
-- **Medienverwaltung**
-  - Upload-Übersicht mit Metadaten  
-  - Wiederverwendung von Medien innerhalb einer Campaign  
-  - Speicherort: Filesystem oder S3-kompatibler Object-Store
-- **Analytics**
-  - Tracking von Likes, Reposts, Replies  
-  - Zeitverlauf-Graphen pro Post und Campaign
-- **Sicherheits-Features**
-  - Token-Verschlüsselung per Envelope-Key pro Tenant  
-  - Audit-Logs für wichtige Aktionen (Posten, Löschen, Rollenzuweisung)
-- **2FA-Vorbereitung**
-  - Tabellen und Flags für TOTP/WebAuthn  
-  - Deaktivierter, aber vorbereiteter MFA-Schritt im Login-Flow
+
+- Mandantentrennung per `tenant_id`, Unique-Constraints pro Tenant, Query-Filter.
+- Benutzer- und Rollenverwaltung (`owner`, `admin`, `editor`, `viewer`) inklusive Einladungen und E-Mail-Verifizierung.
+- Scheduler-Verbesserungen: Retries mit Backoff, Concurrency-Limits, Abbruch und Neuplanung.
+- Medienverwaltung mit Metadaten, Wiederverwendung und optionalem S3-Speicher.
+- Analytics: Erfassung von Likes/Reposts/Replies und Zeitreihen-Auswertung.
+- Sicherheit: Envelope-Verschlüsselung je Tenant, Audit-Logs, vorbereitete 2FA-Tabellen.
 
 ---
 
-## **Phase 3 – Vollständiger Bluesky-Client**
-**Ziel:** Neben Kampagnenplanung wird auch vollständige Interaktion mit Bluesky möglich – ähnlich einem professionellen Social-Media-Tool.
+## Phase 3 – Vollständiger Bluesky-Client
 
-### Client-Funktionen
-- **Timeline-Anzeige**
-  - Home, benutzerdefinierte Feeds, Listen  
-  - Filtern und Suchen in Echtzeit
-- **Interaktion**
-  - Liken, Reposten, Zitieren, Antworten  
-  - Folgen/Entfolgen, Listenverwaltung
-- **Direktnachrichten** *(sofern Bluesky sie implementiert)*
-- **Multi-Account-Unterstützung pro Tenant**
-  - Trennung der Credentials je Account  
-  - Account-spezifische Timeline und Posting-Optionen
-- **Erweiterte Kampagnenfunktionen**
-  - Mehrkanalplanung (mehrere Accounts pro Campaign)  
-  - Crossposting-Vorbereitung (Bluesky + Mastodon + weitere Plattformen)
-- **Erweiterte Sicherheit**
-  - Voll implementierte 2FA (TOTP + Backup-Codes, optional WebAuthn)  
-  - Geräteverwaltung & Login-Benachrichtigungen  
-  - Export/Import kompletter Tenants (inkl. Medien und Einstellungen)
-- **Integrationen**
-  - Webhooks für externe Tools  
-  - API-Endpunkte für Automatisierung  
-  - Optional: Plugin-System
+**Ziel:** Neben der Kampagnenplanung ermöglicht das Tool vollwertige Bluesky-Interaktionen.
+
+### Geplante Funktionen
+
+- Timeline-Ansichten (Home, benutzerdefinierte Feeds, Listen) mit Filter- und Suchfunktionen.
+- Interaktionen: Liken, Reposten, Zitieren, Antworten, Follow/Unfollow, Listenpflege.
+- Direktnachrichten sobald Bluesky sie bereitstellt.
+- Multi-Account-Unterstützung pro Tenant, inklusive Account-spezifischer Timelines.
+- Erweiterte Kampagnenfunktionen (Mehrkanalplanung, Crossposting-Vorbereitung).
+- Sicherheit: Vollständige 2FA (TOTP + Backup-Codes, perspektivisch WebAuthn), Geräteverwaltung, Login-Benachrichtigungen.
+- Integrationen: Webhooks, Automatisierungs-API, optional Plugin-Schnittstelle.
 
 ---
 
-## Hinweise zur Umsetzung
-- **Open Source**: Der Code wird unter einer freien Lizenz veröffentlicht, um Community-Beiträge zu ermöglichen.  
-- **Architekturprinzipien**:  
-  - Von Anfang an Datenbank-agnostisch (SQLite, MySQL, Postgres)  
-  - Strikte Trennung von Mandanten-Daten  
-  - Security-by-Design (Verschlüsselung, Hashing, Audit-Logs)  
-- **Priorisierung**: Jede Phase bringt ein **benutzbares Produkt**, das auf dem vorherigen Stand aufbaut.  
-- **Community-Einbindung**: Feedback und Feature-Requests über Issues und Diskussionen im GitHub-Repository.
+## Leitprinzipien
 
----
+- **Open Source:** Freie Lizenz, Community-Beiträge ausdrücklich erwünscht.
+- **Architektur:** Datenbank-agnostisch, konsequente Mandantentrennung, Security-by-Design.
+- **Priorisierung:** Jede Phase liefert Mehrwert, ohne zukünftige Erweiterungen zu blockieren.
+- **Feedback:** Feature-Requests und Diskussionen über Issues, Roadmap wird kontinuierlich aktualisiert.

--- a/docs/diagramme/datenfluss.md
+++ b/docs/diagramme/datenfluss.md
@@ -1,18 +1,12 @@
-
----
-
-### `docs/diagramme/datenfluss.md`
-```markdown
 # Datenfluss – Post erstellen
 
-Vereinfachtes Sequence‑Diagramm für das Planen und Veröffentlichen eines Posts (Skeet oder Thread).
-```
+Das folgende Sequence-Diagramm beschreibt den regulären Ablauf vom Planen eines Skeets bis zur Veröffentlichung über den Scheduler. Fehler- und Retry-Pfade sind eingezeichnet, um das Verhalten bei API-Problemen zu verdeutlichen.
 
 ```mermaid
 sequenceDiagram
-  participant U as Nutzer:in Browser
+  participant U as Nutzer:in (Browser)
   participant FE as Web-Frontend
-  participant BE as Backend API
+  participant BE as Backend-API
   participant DB as Datenbank
   participant SCH as Scheduler
   participant BSKY as Bluesky API
@@ -22,18 +16,18 @@ sequenceDiagram
   BE->>DB: Speichern mit tenant_id und Status
   BE-->>FE: 201 Created
 
-  SCH->>DB: Fällige Jobs abfragen
+  SCH->>DB: Fällige Jobs abrufen
   SCH->>BE: Job ausführen
-  BE->>DB: Credentials entschlüsseln serverseitig
+  BE->>DB: Credentials entschlüsseln
   BE->>BSKY: Post erstellen
   alt Erfolg
-    BSKY-->>BE: URI Erfolg
+    BSKY-->>BE: URI zurückgeben
   else Fehler
-    BSKY-->>BE: 4xx/5xx
-    BE->>BE: Retry mit Backoff / Markiere failed
+    BSKY-->>BE: 4xx/5xx-Fehler
+    BE->>BE: Retry mit Backoff planen
   end
-  BE->>DB: Status sent und post_uri speichern
-  BE-->>SCH: Job done
+  BE->>DB: Status "sent" und post_uri speichern
+  BE-->>SCH: Job abgeschlossen
   FE->>BE: GET Status
-  BE-->>FE: Aktueller Status sent oder failed
+  BE-->>FE: Aktuellen Status (sent/failed) liefern
 ```

--- a/docs/diagramme/lebenszyklus_skeet.md
+++ b/docs/diagramme/lebenszyklus_skeet.md
@@ -1,13 +1,6 @@
-
----
-
-### `docs/diagramme/lebenszyklus_skeet.md`
-```markdown
 # Lebenszyklus – Skeet
 
-Zustände und Übergänge eines Skeets im Kampagnen‑Bot.  
-Die Farben entsprechen der [Statusfarben‑Legende](./statusfarben.md).
-```
+Das Zustandsdiagramm zeigt alle möglichen Status eines einzelnen Skeets und die wichtigsten Übergänge. Die Farben orientieren sich an der [Statusfarben-Legende](./statusfarben.md).
 
 ```mermaid
 stateDiagram-v2
@@ -35,12 +28,12 @@ stateDiagram-v2
   draft_state --> deleted_state: löschen
 
   scheduled_state --> cancelled_state: stornieren
-  scheduled_state --> sending_state: job startet
+  scheduled_state --> sending_state: Job startet
 
-  sending_state --> sent_state: posten erfolgreich
-  sending_state --> failed_state: posten fehlgeschlagen
+  sending_state --> sent_state: Post erfolgreich
+  sending_state --> failed_state: Fehler beim Versand
 
-  failed_state --> scheduled_state: retry geplant
+  failed_state --> scheduled_state: Retry planen
   failed_state --> cancelled_state: stornieren
   failed_state --> deleted_state: löschen
 

--- a/docs/diagramme/lebenszyklus_thread.md
+++ b/docs/diagramme/lebenszyklus_thread.md
@@ -1,13 +1,6 @@
-
----
-
-### `docs/diagramme/lebenszyklus_thread.md`
-```markdown
 # Lebenszyklus – Thread
 
-Zustände und Übergänge eines Threads.  
-Die Farben entsprechen der [Statusfarben‑Legende](./statusfarben.md).
-```
+Das Diagramm zeigt, wie sich der Status eines mehrteiligen Threads verändert. Übergänge berücksichtigen sowohl erfolgreiche Komplettveröffentlichungen als auch Fehler bei einzelnen Posts.
 
 ```mermaid
 stateDiagram-v2
@@ -35,12 +28,12 @@ stateDiagram-v2
   draft_state --> deleted_state: löschen
 
   scheduled_state --> cancelled_state: stornieren
-  scheduled_state --> sending_state: job startet
+  scheduled_state --> sending_state: Job startet
 
-  sending_state --> sent_state: alle teile gepostet
-  sending_state --> failed_state: teil fehlgeschlagen
+  sending_state --> sent_state: alle Teile gesendet
+  sending_state --> failed_state: Teil fehlgeschlagen
 
-  failed_state --> scheduled_state: retry start/teil
+  failed_state --> scheduled_state: Retry für fehlende Teile
   failed_state --> cancelled_state: stornieren
   failed_state --> deleted_state: löschen
 

--- a/docs/diagramme/statusfarben.md
+++ b/docs/diagramme/statusfarben.md
@@ -1,24 +1,17 @@
-
----
-
-### `docs/diagramme/statusfarben.md`
-```markdown
 # Statusfarben-Legende
 
-Diese Tabelle definiert die Farbzuordnung für alle Stati im BSky-Kampagnen-Bot.  
-Die Hex-Werte werden sowohl in der UI als auch in den Mermaid-Diagrammen verwendet.
+Die Tabelle definiert die Farbzuordnung für Status in UI-Komponenten und Diagrammen. Änderungen sollten synchron im Frontend, in den CSS-Variablen und in den Mermaid-Diagrammen übernommen werden.
 
-| Status      | Farbe (Hex) |
-|-------------|-------------|
-| draft       | `#9e9e9e`   |
-| scheduled   | `#1976d2`   |
-| sending     | `#ff9800`   |
-| sent        | `#4caf50`   |
-| failed      | `#f44336`   |
-| cancelled   | `#757575`   |
-| archived    | `#607d8b`   |
-| deleted     | `#000000`   |
-| Start/End   | `#ffffff`   |
+| Status      | Farbe (Hex) | Verwendung |
+|-------------|-------------|------------|
+| draft       | `#9e9e9e`   | Entwürfe, noch nicht geplant |
+| scheduled   | `#1976d2`   | Geplante Posts/Threads |
+| sending     | `#ff9800`   | Aktive Ausführung im Scheduler |
+| sent        | `#4caf50`   | Erfolgreich veröffentlichte Inhalte |
+| failed      | `#f44336`   | Fehlgeschlagene Jobs |
+| cancelled   | `#757575`   | Manuell gestoppte Jobs |
+| archived    | `#607d8b`   | Archivierte Inhalte |
+| deleted     | `#000000`   | Dauerhaft gelöschte Einträge |
+| Start/End   | `#ffffff`   | Start- bzw. Endknoten in Diagrammen |
 
-Hinweis: Änderungen an den Farben bitte konsistent in UI und Diagrammen übernehmen.
-```
+> Tipp: Für Dark-Mode-Anpassungen den Kontrast mit Tools wie WebAIM prüfen.

--- a/docs/diagramme/systemarchitektur.md
+++ b/docs/diagramme/systemarchitektur.md
@@ -1,15 +1,14 @@
 # Systemarchitektur
 
-Kurzer Überblick über die Hauptkomponenten und ihre Beziehungen.  
-Details zur Gesamtarchitektur findest du auch in der Projektdoku.
+Das Diagramm vermittelt einen schnellen Überblick über die Kernkomponenten des Systems und deren Interaktionen.
 
 ```mermaid
 flowchart TD
-  FE["Web-Frontend React"]
-  BE["Backend API Node-Express"]
-  DB["Datenbank: SQLite / MySQL / Postgres"]
-  SCH["Scheduler Job-Queue"]
-  BSKY["Bluesky API ATProto"]
+  FE["Web-Frontend (React)"]
+  BE["Backend-API (Node/Express)"]
+  DB["Datenbank (SQLite / PostgreSQL / MySQL)"]
+  SCH["Scheduler / Job-Queue"]
+  BSKY["Bluesky API (ATProto)"]
 
   FE --> BE
   BE <--> DB
@@ -17,3 +16,5 @@ flowchart TD
   BE --> BSKY
   SCH --> BSKY
 ```
+
+> Für produktive Setups empfiehlt sich zusätzlich ein Reverse Proxy (z. B. Traefik oder Nginx) vor Backend und Frontend.

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -1,25 +1,22 @@
 # Installation
 
-Dieser Abschnitt beschreibt die verschiedenen Möglichkeiten, den **BSky-Kampagnen-Bot** zu installieren und zu betreiben.  
-Bitte wähle die für dich passende Variante aus.
-
-## Optionen
-
-1. **[Installation auf dem lokalen PC oder Server](local-install.md)**  
-   Für die Ausführung auf einem lokalen Rechner (Windows, macOS, Linux) oder einem eigenen Server ohne Containerisierung.
-
-2. **[Installation auf einem Server](server-install.md)**  
-   Für die direkte Installation auf einem (v)Server oder einer dedizierten Maschine, z. B. im Rechenzentrum oder Cloud-Hoster.
-
-3. **[Installation im Docker-Container](docker-install.md)**  
-   Für eine einfache, isolierte Installation mit Docker und optionaler Docker-Compose-Unterstützung.
+Hier findest du einen Überblick über die verfügbaren Installationswege für den **BSky-Kampagnen-Bot**. Wähle die Variante, die am besten zu deinem Einsatzzweck passt, und folge anschließend der jeweiligen Detailanleitung.
 
 ---
 
-## Hinweise
+## Installationsoptionen
 
-- Vor der Installation sollte geprüft werden, ob alle **Systemvoraussetzungen** erfüllt sind (siehe jeweilige Anleitung).
-- Falls du unsicher bist, welche Option die richtige ist, empfehlen wir die **Docker-Installation** – sie ist am einfachsten zu warten und erfordert keine komplexe lokale Einrichtung.
+1. **[Lokale Installation](./local-install.md)** – ideal für Entwicklung, Tests oder den Betrieb auf dem eigenen Rechner.
+2. **[Manuelle Server-Installation](./server-install.md)** – geeignet für produktive Setups ohne Containerisierung, z. B. auf einem (v)Server.
+3. **[Docker-Installation](./docker-install.md)** – bevorzugte Option für einen reproduzierbaren und isolierten Betrieb mit Docker Compose.
+
+---
+
+## Allgemeine Hinweise
+
+- Prüfe vorab die Systemvoraussetzungen der gewählten Anleitung (Node.js-Version, Datenbank, Docker, …).
+- Sensible Konfigurationsdateien wie `.env` niemals ins Versionskontrollsystem hochladen.
+- Für produktive Umgebungen empfehlen wir einen regelmäßigen Backup-Plan für Datenbank und Konfiguration.
 
 ---
 

--- a/docs/installation/local-install.md
+++ b/docs/installation/local-install.md
@@ -1,61 +1,80 @@
-# Option A: Installation auf lokalem PC
+# Option A: Installation auf einem lokalen Rechner
 
-Diese Methode eignet sich für lokale Entwicklung, Tests oder den direkten Betrieb auf einem Rechner ohne Container.
+Geeignet für lokale Entwicklung, manuelle Tests oder kleine Selbst-Hostings ohne Container. Die Anleitung nutzt Node.js und SQLite als Standarddatenbank.
+
+---
+
+## Voraussetzungen
+
+- Node.js ≥ 20 (inkl. npm)
+- Git
+- Bluesky-Identifier und App-Passwort
+
+Optional:
+- PostgreSQL oder MySQL, falls du nicht mit SQLite arbeiten möchtest
+- `nodemon` für komfortable Entwicklung (per `npm install -g nodemon`)
 
 ---
 
 ## 1. Repository klonen
+
 ```bash
 git clone https://github.com/mkueper/BSky-Kampagnen-Bot.git
 cd BSky-Kampagnen-Bot
 ```
 
-## 2. Backend-Abhängigkeiten installieren
+## 2. Abhängigkeiten installieren
+
 ```bash
 npm install
 ```
 
-## 3. Frontend installieren & bauen
+## 3. Frontend bauen
+
 ```bash
 cd dashboard
 npm install
 npm run build
 cd ..
 ```
-## 4. Konfiguration
 
-- ### 1. env.sample nach .env kopieren:
+> Das Dashboard wird durch `npm run build` in den Ordner `dashboard/dist` gebaut und vom Express-Server ausgeliefert.
+
+## 4. Konfiguration einrichten
+
+1. Beispiel-Environment kopieren:
+   ```bash
+   cp .env.sample .env
+   ```
+2. Zugangsdaten in `.env` ergänzen:
+   ```ini
+   BLUESKY_SERVER=https://bsky.social
+   BLUESKY_IDENTIFIER=dein_handle.bsky.social
+   BLUESKY_APP_PASSWORD=dein_app_passwort
+   ```
+3. Optional: Zeitzone und Datenbanktyp anpassen (siehe Kommentare in `.env`).
+
+## 5. Datenbank vorbereiten (optional, empfohlen)
+
 ```bash
-    cp .env.sample .env
-```
-- ### 2. Zugangsdaten für Bluesky eintragen:
-```ini
-    BLUESKY_SERVER=https://bsky.social
-    BLUESKY_IDENTIFIER=dein_handle.bsky.social
-    BLUESKY_APP_PASSWORD=dein_passwort
-```
-- ### 3. Optional Zeitzone einstellen:
-```ini
-    VITE_TIME_ZONE=Europe/Berlin
+npm run migrate:dev
+# optional Seeds laden:
+npm run seed:dev
 ```
 
-## 5. Server starten
+## 6. Server starten
+
 ```bash
-node server.js
+npm run dev
 ```
 
-Der Server ist erreichbar unter: http://localhost:3000
+Der Server lauscht standardmäßig auf <http://localhost:3000>. Für einen produktionsähnlichen Start verwende `npm start`.
 
 ---
 
-## Hinweise & Tipps
+## Zusätzliche Hinweise
 
-- **Datenbank:** Standardmäßig SQLite-Datei im Projektverzeichnis. Für MySQL/PostgreSQL in .env umstellen.
-
-- **Logs:** Standardausgabe in der Konsole. Bei Bedarf Umleitung in Logdateien.
-
-- **Entwicklung:** Mit nodemon kannst du automatische Neustarts bei Codeänderungen aktivieren.
-
-- **Sicherheit:** .env niemals ins Git-Repository hochladen.
-
-- **Backups:** Bei SQLite einfach die DB-Datei sichern. Bei MySQL/PostgreSQL die Tools mysqldump bzw. pg_dump verwenden.
+- **Datenbank:** Ohne weitere Konfiguration wird eine SQLite-Datei im Projektverzeichnis erstellt. Für PostgreSQL/MySQL entsprechende Verbindungsdaten in `.env` setzen.
+- **Logs:** Standardmäßig werden Logs in der Konsole ausgegeben. Für lokale Tests kann `npm run dev` mit automatischem Reload genutzt werden.
+- **Sicherheit:** `.env` niemals ins Repository einchecken. Verwende für Tests Dummy-Zugangsdaten.
+- **Backups:** Bei SQLite reicht das Kopieren der Datenbankdatei. Für andere Datenbanken stehen `pg_dump` bzw. `mysqldump` zur Verfügung.

--- a/docs/installation/server-install.md
+++ b/docs/installation/server-install.md
@@ -1,27 +1,38 @@
 # Option B: Manuelle Installation auf einem Server
 
-Diese Methode eignet sich für produktive Umgebungen ohne Container, bei denen alle Abhängigkeiten manuell aufgesetzt werden.
+Für produktive Umgebungen ohne Containerisierung. Die folgenden Schritte richten sich an Administrator:innen mit Shell-Zugriff (z. B. auf einen vServer oder eine dedizierte Maschine).
+
+---
 
 ## Voraussetzungen
-- Node.js (Version 20 oder höher)
-- npm (im Lieferumfang von Node.js enthalten)
-- SQLite oder eine alternative unterstützte Datenbank (MySQL/PostgreSQL)
-- Git
-- Optional: Prozessmanager wie `pm2` oder Systemd
 
+- Linux-Server mit Shell-Zugriff (Ubuntu/Debian/Fedora o. Ä.)
+- Node.js ≥ 20 und npm
+- Git
+- Unterstützte Datenbank (SQLite, PostgreSQL oder MySQL)
+- Prozessmanager (empfohlen): `pm2` oder systemd-Service
+
+Optional:
+- Reverse Proxy wie Nginx oder Traefik für HTTPS-Terminierung
+- Backup-Strategie für Datenbank und `.env`
+
+---
 
 ## 1. Repository klonen
+
 ```bash
 git clone https://github.com/mkueper/BSky-Kampagnen-Bot.git
 cd BSky-Kampagnen-Bot
 ```
 
-## 2. Backend-Abhängigkeiten installieren
+## 2. Abhängigkeiten installieren
+
 ```bash
 npm install --production
 ```
 
-## 3. Frontend installieren & bauen
+## 3. Frontend bauen
+
 ```bash
 cd dashboard
 npm install --production
@@ -29,33 +40,41 @@ npm run build
 cd ..
 ```
 
-## 4. Konfiguration
-1. .env.sample nach .env kopieren und anpassen.
-2. Zugangsdaten für Bluesky und optionale Zeitzone eintragen.
-3. .env sicher auf dem Server ablegen.
+## 4. Konfiguration hinterlegen
 
----
-## 5. Start im Hintergrund (pm2-Beispiel)
+1. `.env.sample` kopieren und anpassen:
+   ```bash
+   cp .env.sample .env
+   ```
+2. Bluesky-Zugangsdaten und gewünschte Datenbankverbindung eintragen.
+3. `.env` nur für berechtigte Benutzer:innen lesbar machen (`chmod 600 .env`).
+
+## 5. Datenbank migrieren
+
+```bash
+npm run migrate:prod
+# optional Seeds für Demo-Daten:
+npm run seed:prod
+```
+
+## 6. Dienst starten (Beispiel mit pm2)
+
 ```bash
 npm install -g pm2
 pm2 start server.js --name bsky-bot
 pm2 save
 ```
-Mit ```pm2 restart bsky-bot``` kann der Dienst neu gestartet werden.
+
+- Neustart nach Änderungen: `pm2 restart bsky-bot`
+- Logs ansehen: `pm2 logs bsky-bot`
+
+Alternativ kann ein systemd-Service erstellt werden, der `npm start` ausführt.
 
 ---
 
-## Hinweise & Tipps
+## Betriebs- und Sicherheitshinweise
 
-- **Datenbank:** SQLite-Datei oder Anbindung an MySQL/PostgreSQL auf demselben oder einem anderen Server möglich.
-
-- **Logs:** Mit pm2 logs bsky-bot oder Systemd-Logs einsehbar (journalctl -u bsky-bot).
-
-- **Sicherheit:**
-  - Firewall-Regeln setzen (nur notwendige Ports öffnen)
-  - Reverse Proxy mit HTTPS verwenden (z. B. Nginx, Traefik)
-  - Starke Passwörter und sichere .env-Datei verwenden
-
-- **Backups:** Datenbank und .env regelmäßig sichern.
-
-- **Updates:** Vor einem Update pm2 stop bsky-bot, Repo aktualisieren, erneut bauen, dann starten.
+- **Datenbank:** Bei externen Datenbanken sicherstellen, dass Firewalls nur vertrauenswürdige Verbindungen zulassen.
+- **HTTPS:** Reverse Proxy mit Zertifikatsverwaltung (z. B. Let’s Encrypt) vor das Backend schalten.
+- **Backups:** Datenbank und `.env` regelmäßig sichern; bei PostgreSQL/MySQL automatisierte Dumps einrichten.
+- **Updates:** Vor Updates `pm2 stop bsky-bot`, Repository aktualisieren (`git pull`), Abhängigkeiten prüfen, erneut bauen und Dienst starten.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,44 +1,55 @@
-# scripts/ – Hilfsskripte für den BSKY‑Kampagnen‑Bot
+# scripts – Hilfswerkzeuge für den BSky-Kampagnen-Bot
 
-Dieses Verzeichnis enthält **manuell ausführbare** Hilfsskripte (z. B. Smoke‑Tests, One‑Off‑Tasks, Migrations‑Helper).  
-Sie sind **nicht** Teil des Produktions‑Builds.
+Das Verzeichnis enthält manuell ausführbare TypeScript-Skripte für Smoke-Tests und Wartungsaufgaben. Sie sind nicht Teil des regulären Builds, können aber bei Entwicklung, Fehleranalyse oder Integrationen unterstützen.
 
 ---
 
 ## Voraussetzungen
 
 - Node.js ≥ 20
-- Abhängigkeiten installiert: `npm i`
-- TypeScript + ts-node verfügbar:
-  ```bash
-  npm i -D typescript ts-node
-  ```
+- Projektabhängigkeiten installiert (`npm install`)
+- TypeScript/TSX-Laufzeit (wird automatisch über `devDependencies` bereitgestellt)
+
+> Empfehlung: Skripte via `npx tsx` oder über die hinterlegten npm-Skripte starten.
+
 ---
 
 ## Struktur
 
-```bash
+```
 scripts/
-├─ smokeBlueskyPost.ts   # Minimaler End‑to‑End‑Test zum Posten auf Bluesky
-└─ README.md             # Diese Datei
+├─ checkEnvUsage.ts       # Prüft, ob Variablen aus .env im Code verwendet werden
+├─ smokeBlueskyPost.ts    # Minimaler End-to-End-Test für Bluesky-Posts
+├─ smokeMastodonPost.ts   # Experimenteller Smoke-Test für Mastodon (optional)
+└─ README.md
 ```
-Benennung: themaAktion.ts (z. B. dbMigrateOnce.ts, mastodonSmoke.ts).
 
-## Schnellstart
-Bluesky Smoke‑Test ausführen
+Namenskonvention: `themaAktion.ts` (z. B. `dbMigrateOnce.ts`).
 
-Postet einen kurzen Test‑Skeet über das Plattform‑Profil „bluesky“.
+---
+
+## Ausführen von Skripten
+
+### Bluesky-Smoke-Test
 
 ```bash
-npx ts-node scripts/smokeBlueskyPost.ts
+npm run smoke:bsky
+# alternativ
+npx tsx scripts/smokeBlueskyPost.ts
 ```
 
-Oder als NPM‑Script (Empfehlung – in package.json):
-```json
-"scripts": {
-  "smoke": "ts-node scripts/smokeBlueskyPost.ts"
-}
-```
+### Mastodon-Smoke-Test
+
 ```bash
-npm run smoke
+npm run smoke:masto
+# alternativ
+npx tsx scripts/smokeMastodonPost.ts
 ```
+
+### Environment-Check
+
+```bash
+npx tsx scripts/checkEnvUsage.ts
+```
+
+Die Skripte greifen auf `.env` zu. Verwende für Tests separate Zugangsdaten oder eine abgesicherte Test-Instanz.


### PR DESCRIPTION
## Summary
- rewrite the top-level README with clearer goals, stack overview, and doc links
- clean up documentation structure, fixing outdated references and improving agent, roadmap, and installation guides
- normalize diagram markdown, add missing details, and update script and styling guides

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cc1d07743c832d9865b66fe06cd8cc